### PR TITLE
Disable blacklisting of kubelet service

### DIFF
--- a/filter/logfilter.go
+++ b/filter/logfilter.go
@@ -40,7 +40,6 @@ var (
 	blacklistedUnits = map[string]bool{
 		"log-collector.service":      true,
 		"logstash-forwarder.service": true,
-		"kubelet.service":            true,
 		"flanneld.service":           true,
 	}
 


### PR DESCRIPTION
- this will facilitate identifying and debugging the container conflict errors, see https://github.com/kubernetes/kubernetes/pull/40448
- see logs in Splunk now: `index IN ("content_test") environment IN ("upp-k8s-dev-delivery-eu","upp-k8s-dev-publish-eu") SYSTEMD_UNIT="kubelet.service"`
- ~50K logs/hour